### PR TITLE
fixes problem with space in bibtex

### DIFF
--- a/bibtex_style.csl
+++ b/bibtex_style.csl
@@ -60,10 +60,15 @@
         <text macro="issued-year"/>
       </group>
   </macro>
+  <locale>
+    <terms>
+      <term name="et-al-custom">etal.</term>
+    </terms>
+  </locale>
   <macro name="author-short">
     <names variable="author">
       <name form="short" delimiter="_" delimiter-precedes-last="always" et-al-min="2" et-al-use-first="2"/>
-      <et-al font-style="italic"/>
+      <et-al term="et-al-custom" font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>


### PR DESCRIPTION
Hi. Thank you for your solution; it was really helpful to me. I encountered a small problem with Overleaf rendering while using it.

I have Zotero version 6.0.36. You can reproduce the problem with this paper - https://arxiv.org/abs/2303.04347. 

If I add a citation from the browser, I receive the output below and with space between at and al it does not render properly in Overleaf:
\cite{Bu_Fang_et al._2023} 

 @article{Bu_Fang_et al._2023, title={Optimal ANN-SNN Conversion for High-accuracy and Ultra-low-latency Spiking Neural Networks}, url={http://arxiv.org/abs/2303.04347}, DOI={10.48550/arXiv.2303.04347}, note={arXiv:2303.04347 [cs]}, number={arXiv:2303.04347}, publisher={arXiv}, author={Bu, Tong and Fang, Wei and Ding, Jianhao and Dai, PengLin and Yu, Zhaofei and Huang, Tiejun}, year={2023}, month={Mar} }

With my fix, you receive this, without space between at and al and this fixes rendering problem in Overleaf
\cite{Bu_Fang_etal._2023}

 @article{Bu_Fang_etal._2023, title={Optimal ANN-SNN Conversion for High-accuracy and Ultra-low-latency Spiking Neural Networks}, url={http://arxiv.org/abs/2303.04347}, DOI={10.48550/arXiv.2303.04347}, note={arXiv:2303.04347 [cs]}, number={arXiv:2303.04347}, publisher={arXiv}, author={Bu, Tong and Fang, Wei and Ding, Jianhao and Dai, PengLin and Yu, Zhaofei and Huang, Tiejun}, year={2023}, month={Mar} }